### PR TITLE
Fixed links in halloween cat card

### DIFF
--- a/index.html
+++ b/index.html
@@ -271,9 +271,9 @@
 
     <!-- Martyav -->
     <div class='card'>
-      <a href='./Art/martyav/halloween_cat.html' target='_blank'>
+      <a href='./Art/Martyav/halloween_cat.html' target='_blank'>
         <p class='project-name'>Halloween Cat</p>
-        <img src='./Art/martyav/halloween_cat.png' alt='A black cat, under green text stating, "Happy Halloween!"'/>
+        <img src='./Art/Martyav/halloween_cat.png' alt='A black cat, under green text stating, "Happy Halloween!"'/>
       </a>
       <p class='author'>by
         <a href="https://github.com/martyav" target="_blank">Martyav</a>


### PR DESCRIPTION
The links are case sensitive. I had saved the correct version of the file locally before making the pull request, but I was inside another directory in git bash when I committed, so the change to the root index was not staged.