### PR TITLE
Markdown Styling on link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Now, once you've forked this repo and got a local version up on your computer, f
 2. Within this folder you just made, create two files, an HTML file and a CSS file.
 3. Link your CSS file to your HTML file.
 4. Using only HTML and CSS (no <script> allowed!!), create a work of art! It can be as simple or as complex as you like.
-5. Take a screenshot of your finished work! Try to crop it so that it looks good as a smallish image. Save this in your directory, together with your html and css files.
+5. Take a screenshot of your finished work and upload it as a PNG along with your html and css files. People browsing the folder want to easily see your work!
 6. Go to the root index.html. You will see a `<div>` that has a class of 'card'. Here is the first example:
 
 ```

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 Welcome to CSS Art, a fun, beginner-friendly challenge for Hacktoberfest!
 
 What shapes, pictures and animations can you come up with, using plain HTML divs and CSS? Let's showcase the artistry of ZTM students, and get a free t-shirt into the bargain!
-If you're not sure what this is or how to go about doing it, take a look at  https://codepen.io/mikemang/post/a-beginner-s-guide-to-pure-css-images , which will teach you all about how to make CSS images.
+If you're not sure what this is or how to go about doing it, take a look at [some tutorials on codepen](https://codepen.io/mikemang/post/a-beginner-s-guide-to-pure-css-images). Our tutorials will teach you all about how to make CSS images.
 
 # What is Hacktoberfest?
-Every October, Digital Ocean runs Hacktoberfest, a month-long celebration of open-source software! All you have to do to take part is sign up on their website - https://hacktoberfest.digitalocean.com/ - and make five pull requests in the month of October. Any pull request to any public repo on Github will count, which means, of course, that any PRs you make to this project will help you on your way to getting a cool t-shirt!
+Every October, Digital Ocean runs Hacktoberfest, a month-long celebration of open-source software! All you have to do to take part is sign up on their website [here](https://hacktoberfest.digitalocean.com/)  - and make five pull requests in the month of October. Any pull request to any public repo on Github will count, which means, of course, that any PRs you make to this project will help you on your way to getting a cool t-shirt!
 
 # Instructions
 If you've never forked a repository or made a pull request before, we recommend making your first one over at https://github.com/zero-to-mastery/start-here-guidelines . That will count towards your total, and then you'll be ready to take on this challenge with your new GitHub skills!


### PR DESCRIPTION
For some of the longer links like the tutorial pointing over to to the code pen tutorials for css art I just added ma markdown style link to shorten it. I left the link which gives to link to the repo to clone/fork for a PR in it's 'long' format so people can easily just copy paste it to their terminal. 